### PR TITLE
Ensure batch mode toggles around crafting

### DIFF
--- a/Toms-Storage-120/src/loader-shared/java/com/tom/storagemod/tile/CraftingTerminalBlockEntity.java
+++ b/Toms-Storage-120/src/loader-shared/java/com/tom/storagemod/tile/CraftingTerminalBlockEntity.java
@@ -218,7 +218,7 @@ public class CraftingTerminalBlockEntity extends StorageTerminalBlockEntity {
 				craftingCooldown += craftResult.getItem(0).getCount();
                                if (playerInvUpdate) thePlayer.containerMenu.broadcastChanges();
                        } finally {
-                               // Assurer que le flag est réinitialisé même en cas d'exception
+                               // Ensure the flag resets even if an exception occurs
                                refillingGrid = false;
                                MultiItemHandler.disableBatchMode();
                        }

--- a/Toms-Storage-120/src/loader-shared/java/com/tom/storagemod/tile/CraftingTerminalBlockEntity.java
+++ b/Toms-Storage-120/src/loader-shared/java/com/tom/storagemod/tile/CraftingTerminalBlockEntity.java
@@ -105,9 +105,10 @@ public class CraftingTerminalBlockEntity extends StorageTerminalBlockEntity {
 		return craftResult;
 	}
 
-	public void craft(Player thePlayer) {
-		if(currentRecipe != null) {
-			try {
+       public void craft(Player thePlayer) {
+               if(currentRecipe != null) {
+                       MultiItemHandler.enableBatchMode();
+                       try {
 				long currentTime = System.currentTimeMillis();
 				boolean useCache = currentTime - lastCraftTime < CACHE_VALIDITY_PERIOD;
 				lastCraftTime = currentTime;
@@ -215,13 +216,14 @@ public class CraftingTerminalBlockEntity extends StorageTerminalBlockEntity {
 				refillingGrid = false;
 				onCraftingMatrixChanged();
 				craftingCooldown += craftResult.getItem(0).getCount();
-				if (playerInvUpdate) thePlayer.containerMenu.broadcastChanges();
-			} finally {
-				// Assurer que le flag est réinitialisé même en cas d'exception
-				refillingGrid = false;
-			}
-		}
-	}
+                               if (playerInvUpdate) thePlayer.containerMenu.broadcastChanges();
+                       } finally {
+                               // Assurer que le flag est réinitialisé même en cas d'exception
+                               refillingGrid = false;
+                               MultiItemHandler.disableBatchMode();
+                       }
+               }
+       }
 
 	/**
 	 * Génère une clé unique pour identifier un item et ses tags


### PR DESCRIPTION
## Summary
- call `MultiItemHandler.enableBatchMode()` before crafting logic
- guarantee `MultiItemHandler.disableBatchMode()` in the `finally` block

## Testing
- `./gradlew --refresh-dependencies build` *(fails: Plugin not found due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683f668b7c1c83239f8ac573342d03cf