### PR TITLE
Fix crafting filler caching

### DIFF
--- a/Toms-Storage-120/src/loader-shared/java/com/tom/storagemod/tile/CraftingTerminalBlockEntity.java
+++ b/Toms-Storage-120/src/loader-shared/java/com/tom/storagemod/tile/CraftingTerminalBlockEntity.java
@@ -118,20 +118,24 @@ public class CraftingTerminalBlockEntity extends StorageTerminalBlockEntity {
 				boolean playerInvUpdate = false;
 				refillingGrid = true;
 
-				// Groupe les items identiques pour réduire le nombre d'appels à pullStack
-				Map<String, Integer> neededItems = new HashMap<>();
-				Map<String, ItemStack> itemTemplates = new HashMap<>();
+                               // Groupe les items identiques pour réduire le nombre d'appels à pullStack
+                               Map<String, Integer> neededItems = new HashMap<>();
+                               Map<String, ItemStack> itemTemplates = new HashMap<>();
 
-				// 1. Collecter les besoins
-				for (int i = 0; i < craftMatrix.getContainerSize(); ++i) {
-					ItemStack slot = craftMatrix.getItem(i);
-					if (!slot.isEmpty()) {
-						ItemStack oldItem = slot.copy();
-						String key = getItemKey(oldItem);
-						neededItems.put(key, neededItems.getOrDefault(key, 0) + 1);
-						itemTemplates.put(key, oldItem.copy());
-					}
-				}
+                               // 1. Collecter uniquement les besoins réels de réapprovisionnement
+                               for (int i = 0; i < craftMatrix.getContainerSize(); ++i) {
+                                       ItemStack slot = craftMatrix.getItem(i);
+                                       ItemStack rem = remainder.get(i);
+                                       if (!slot.isEmpty()) {
+                                               // Si le slot va devenir vide et qu'il n'y a pas de reste à replacer
+                                               if (slot.getCount() <= 1 && rem.isEmpty()) {
+                                                       ItemStack oldItem = slot.copy();
+                                                       String key = getItemKey(oldItem);
+                                                       neededItems.put(key, neededItems.getOrDefault(key, 0) + 1);
+                                                       itemTemplates.putIfAbsent(key, oldItem.copy());
+                                               }
+                                       }
+                               }
 
 				// Si les besoins sont identiques à la dernière opération, utiliser le cache
 				boolean needsAreSame = useCache && neededItems.equals(lastItemsCount);
@@ -171,10 +175,10 @@ public class CraftingTerminalBlockEntity extends StorageTerminalBlockEntity {
 					}
 				}
 
-                                // 3. Application optimisée à la grille de craft
-                                for (int i = 0; i < remainder.size(); ++i) {
-                                        ItemStack slot = craftMatrix.getItem(i);
-                                        ItemStack rem = remainder.get(i);
+                               // 3. Application optimisée à la grille de craft
+                               for (int i = 0; i < remainder.size(); ++i) {
+                                       ItemStack slot = craftMatrix.getItem(i);
+                                       ItemStack rem = remainder.get(i);
 
                                         if (!slot.isEmpty()) {
                                                 String key = getItemKey(slot);
@@ -224,10 +228,26 @@ public class CraftingTerminalBlockEntity extends StorageTerminalBlockEntity {
                                                                 craftMatrix.setItem(i, rem.copy());
                                                         }
                                                 }
-                                        } else if (!rem.isEmpty()) {
-                                                craftMatrix.setItem(i, rem.copy());
-                                        }
-                                }
+
+                                       } else if (!rem.isEmpty()) {
+                                               craftMatrix.setItem(i, rem.copy());
+                                       }
+                               }
+
+                               // Retourner les items non utilisés à la storage
+                               for (List<ItemStack> lst : extractedItems.values()) {
+                                       for (ItemStack is : lst) {
+                                               if (!is.isEmpty()) {
+                                                       StoredItemStack st0 = pushStack(new StoredItemStack(is));
+                                                       if (st0 != null) {
+                                                               ItemStack item = st0.getActualStack();
+                                                               thePlayer.getInventory().add(item);
+                                                               if (!item.isEmpty())
+                                                                       dropItem(item);
+                                                       }
+                                               }
+                                       }
+                               }
 
 				refillingGrid = false;
 				onCraftingMatrixChanged();

--- a/Toms-Storage-120/src/loader-shared/java/com/tom/storagemod/tile/CraftingTerminalBlockEntity.java
+++ b/Toms-Storage-120/src/loader-shared/java/com/tom/storagemod/tile/CraftingTerminalBlockEntity.java
@@ -171,47 +171,63 @@ public class CraftingTerminalBlockEntity extends StorageTerminalBlockEntity {
 					}
 				}
 
-				// 3. Application optimisée à la grille de craft
-				for (int i = 0; i < remainder.size(); ++i) {
-					ItemStack slot = craftMatrix.getItem(i);
-					ItemStack rem = remainder.get(i);
+                                // 3. Application optimisée à la grille de craft
+                                for (int i = 0; i < remainder.size(); ++i) {
+                                        ItemStack slot = craftMatrix.getItem(i);
+                                        ItemStack rem = remainder.get(i);
 
-					if (!slot.isEmpty()) {
-						String key = getItemKey(slot);
-						craftMatrix.removeItem(i, 1);
+                                        if (!slot.isEmpty()) {
+                                                String key = getItemKey(slot);
+                                                craftMatrix.removeItem(i, 1);
+                                                ItemStack after = craftMatrix.getItem(i);
 
-						// Utiliser un item extrait si disponible
-						if (extractedItems.containsKey(key) && !extractedItems.get(key).isEmpty()) {
-							List<ItemStack> items = extractedItems.get(key);
-							craftMatrix.setItem(i, items.remove(0));
-						}
-						// Sinon, essayer l'inventaire du joueur si autorisé
-						else if ((getSorting() & (1 << 8)) != 0) {
-							boolean found = false;
-							for (int j = 0; j < thePlayer.getInventory().getContainerSize(); j++) {
-								ItemStack st = thePlayer.getInventory().getItem(j);
-								if (ItemStack.isSameItemSameTags(slot, st)) {
-									st = thePlayer.getInventory().removeItem(j, 1);
-									if (!st.isEmpty()) {
-										craftMatrix.setItem(i, st);
-										playerInvUpdate = true;
-										found = true;
-										break;
-									}
-								}
-							}
+                                                // Gestion de l'item de reste (bucket, etc.)
+                                                if (!rem.isEmpty()) {
+                                                        if (after.isEmpty()) {
+                                                                craftMatrix.setItem(i, rem.copy());
+                                                                after = craftMatrix.getItem(i);
+                                                        } else if (ItemStack.isSameItemSameTags(after, rem)) {
+                                                                after.grow(rem.getCount());
+                                                                craftMatrix.setItem(i, after);
+                                                        } else {
+                                                                StoredItemStack st0 = pushStack(new StoredItemStack(rem.copy()));
+                                                                if (st0 != null) {
+                                                                        ItemStack is = st0.getActualStack();
+                                                                        thePlayer.getInventory().add(is);
+                                                                        if (!is.isEmpty())
+                                                                                dropItem(is);
+                                                                }
+                                                        }
+                                                }
 
-							// Rien trouvé, on place l'item de reste s'il existe
-							if (!found && !rem.isEmpty()) {
-								craftMatrix.setItem(i, rem.copy());
-							}
-						}
-					}
-					// Gérer les items de reste
-					else if (!rem.isEmpty()) {
-						craftMatrix.setItem(i, rem.copy());
-					}
-				}
+                                                if (craftMatrix.getItem(i).isEmpty()) {
+                                                        boolean filled = false;
+                                                        if (extractedItems.containsKey(key) && !extractedItems.get(key).isEmpty()) {
+                                                                List<ItemStack> items = extractedItems.get(key);
+                                                                craftMatrix.setItem(i, items.remove(0));
+                                                                filled = true;
+                                                        } else if ((getSorting() & (1 << 8)) != 0) {
+                                                                for (int j = 0; j < thePlayer.getInventory().getContainerSize(); j++) {
+                                                                        ItemStack st = thePlayer.getInventory().getItem(j);
+                                                                        if (ItemStack.isSameItemSameTags(slot, st)) {
+                                                                                st = thePlayer.getInventory().removeItem(j, 1);
+                                                                                if (!st.isEmpty()) {
+                                                                                        craftMatrix.setItem(i, st);
+                                                                                        playerInvUpdate = true;
+                                                                                        filled = true;
+                                                                                }
+                                                                                break;
+                                                                        }
+                                                                }
+                                                        }
+                                                        if (!filled && !rem.isEmpty() && craftMatrix.getItem(i).isEmpty()) {
+                                                                craftMatrix.setItem(i, rem.copy());
+                                                        }
+                                                }
+                                        } else if (!rem.isEmpty()) {
+                                                craftMatrix.setItem(i, rem.copy());
+                                        }
+                                }
 
 				refillingGrid = false;
 				onCraftingMatrixChanged();

--- a/Toms-Storage-120/src/shared/java/com/tom/storagemod/gui/CraftingTerminalMenu.java
+++ b/Toms-Storage-120/src/shared/java/com/tom/storagemod/gui/CraftingTerminalMenu.java
@@ -39,8 +39,9 @@ public class CraftingTerminalMenu extends StorageTerminalMenu implements IAutoFi
 
 	private final CraftingContainer craftMatrix;
 	private final ResultContainer craftResult;
-	private Slot craftingResultSlot;
-	private final List<ContainerListener> listeners = Lists.newArrayList();
+       private Slot craftingResultSlot;
+       private final List<ContainerListener> listeners = Lists.newArrayList();
+       private final TerminalCraftingFiller craftingFiller;
 
 	@Override
 	public void addSlotListener(ContainerListener listener) {
@@ -54,29 +55,33 @@ public class CraftingTerminalMenu extends StorageTerminalMenu implements IAutoFi
 		listeners.remove(listener);
 	}
 
-	public CraftingTerminalMenu(int id, Inventory inv, CraftingTerminalBlockEntity te) {
-		super(Content.craftingTerminalCont.get(), id, inv, te);
-		craftMatrix = te.getCraftingInv();
-		craftResult = te.getCraftResult();
-		init();
-		this.addPlayerSlots(inv, 8, 174);
-		te.registerCrafting(this);
-	}
+       public CraftingTerminalMenu(int id, Inventory inv, CraftingTerminalBlockEntity te) {
+               super(Content.craftingTerminalCont.get(), id, inv, te);
+               craftMatrix = te.getCraftingInv();
+               craftResult = te.getCraftResult();
+               craftingFiller = new TerminalCraftingFiller(te, inv.player, sync);
+               init();
+               this.addPlayerSlots(inv, 8, 174);
+               te.registerCrafting(this);
+       }
 
-	public CraftingTerminalMenu(int id, Inventory inv) {
-		super(Content.craftingTerminalCont.get(), id, inv);
-		craftMatrix = new TransientCraftingContainer(this, 3, 3);
-		craftResult = new ResultContainer();
-		init();
-		this.addPlayerSlots(inv, 8, 174);
-	}
+       public CraftingTerminalMenu(int id, Inventory inv) {
+               super(Content.craftingTerminalCont.get(), id, inv);
+               craftMatrix = new TransientCraftingContainer(this, 3, 3);
+               craftResult = new ResultContainer();
+               craftingFiller = null;
+               init();
+               this.addPlayerSlots(inv, 8, 174);
+       }
 
-	@Override
-	public void removed(Player playerIn) {
-		super.removed(playerIn);
-		if(te != null)
-			((CraftingTerminalBlockEntity) te).unregisterCrafting(this);
-	}
+       @Override
+       public void removed(Player playerIn) {
+               super.removed(playerIn);
+               if(te != null) {
+                       ((CraftingTerminalBlockEntity) te).unregisterCrafting(this);
+               }
+               if(craftingFiller != null) craftingFiller.flushBatchBuffer();
+       }
 
 	private void init() {
 		int x = -4;
@@ -236,15 +241,15 @@ public class CraftingTerminalMenu extends StorageTerminalMenu implements IAutoFi
 	@Override
 	public void receive(CompoundTag message) {
 		super.receive(message);
-		if(message.contains("fill")) {
-			var id = ResourceLocation.tryParse(message.getString("fill"));
-			if (id != null) {
-				var recipe = pinv.player.level().getRecipeManager().byKey(id).orElse(null);
-				if (recipe != null) {
-					new TerminalCraftingFiller((CraftingTerminalBlockEntity) te, pinv.player, sync).placeRecipe(recipe);
-				}
-			}
-		}
+               if(message.contains("fill")) {
+                       var id = ResourceLocation.tryParse(message.getString("fill"));
+                       if (id != null) {
+                               var recipe = pinv.player.level().getRecipeManager().byKey(id).orElse(null);
+                               if (recipe != null && craftingFiller != null) {
+                                       craftingFiller.placeRecipe(recipe);
+                               }
+                       }
+               }
 	}
 
 	@Override

--- a/Toms-Storage-120/src/shared/java/com/tom/storagemod/util/TerminalCraftingFiller.java
+++ b/Toms-Storage-120/src/shared/java/com/tom/storagemod/util/TerminalCraftingFiller.java
@@ -29,11 +29,11 @@ public class TerminalCraftingFiller {
 	// Cache with WeakHashMap to allow garbage collection of unused recipes
 	private static final Map<Recipe<?>, Map<StoredItemStack, Integer>> recipeIngredientCache = new WeakHashMap<>(100);
 
-	// Counter to track consecutive crafts of the same recipe for batch optimizations
-	private static Recipe<?> lastRecipe = null;
-	private static int consecutiveCrafts = 0;
-	private static final int BATCH_THRESHOLD = 5; // Start batch processing after this many consecutive crafts
-	private static Map<StoredItemStack, StoredItemStack> batchPullBuffer = null;
+       // Counter to track consecutive crafts of the same recipe for batch optimizations
+       private Recipe<?> lastRecipe = null;
+       private int consecutiveCrafts = 0;
+       private static final int BATCH_THRESHOLD = 5; // Start batch processing after this many consecutive crafts
+       private Map<StoredItemStack, StoredItemStack> batchPullBuffer = null;
 
 	// Stats tracking to optimize cache management
 	private static long lastCacheClear = System.currentTimeMillis();
@@ -48,33 +48,34 @@ public class TerminalCraftingFiller {
 	public void placeRecipe(Recipe<?> recipe) {
 		 // Periodic cache maintenance to prevent memory leaks
 		long currentTime = System.currentTimeMillis();
-		if (currentTime - lastCacheClear > CACHE_CLEAR_INTERVAL) {
-			recipeIngredientCache.clear();
-			batchPullBuffer = null;
-			lastRecipe = null;
-			consecutiveCrafts = 0;
-			lastCacheClear = currentTime;
-		}
+               if (currentTime - lastCacheClear > CACHE_CLEAR_INTERVAL) {
+                       recipeIngredientCache.clear();
+                       flushBatchBuffer();
+                       batchPullBuffer = null;
+                       lastRecipe = null;
+                       consecutiveCrafts = 0;
+                       lastCacheClear = currentTime;
+               }
 
 		// Track consecutive crafts of the same recipe
-		if (recipe.equals(lastRecipe)) {
-			consecutiveCrafts++;
-		} else {
-			lastRecipe = recipe;
-			consecutiveCrafts = 0;
-			batchPullBuffer = null;
-		}
+               if (recipe.equals(lastRecipe)) {
+                       consecutiveCrafts++;
+               } else {
+                       flushBatchBuffer();
+                       lastRecipe = recipe;
+                       consecutiveCrafts = 0;
+                       batchPullBuffer = null;
+               }
 
 		// Clear crafting grid
 		te.clear(player);
 
-		// Load inventory items only once - loading on demand improves performance
-		if (allItems.isEmpty()) {
-			sync.fillCraftingFiller(this);
-			for (var i : player.getInventory().items) {
-				accountStack(i);
-			}
-		}
+               // Refresh cached inventory before each recipe fill
+               allItems.clear();
+               sync.fillCraftingFiller(this);
+               for (var i : player.getInventory().items) {
+                       accountStack(i);
+               }
 
 		// Calculate grid width
 		int rw = calculateRecipeWidth(recipe);
@@ -236,9 +237,21 @@ public class TerminalCraftingFiller {
 		return false;
 	}
 
-	public void accountStack(ItemStack st) {
-		if (st.isEmpty() || st.hasCustomHoverName()) return;
-		int index = StackedContents.getStackingIndex(st);
-		allItems.computeIfAbsent(index, __ -> new ArrayList<>()).add(st);
-	}
+        public void accountStack(ItemStack st) {
+                if (st.isEmpty() || st.hasCustomHoverName()) return;
+                int index = StackedContents.getStackingIndex(st);
+                allItems.computeIfAbsent(index, __ -> new ArrayList<>()).add(st);
+        }
+
+       public void flushBatchBuffer() {
+               if (batchPullBuffer != null && !batchPullBuffer.isEmpty()) {
+                       for (var stack : batchPullBuffer.values()) {
+                               if (stack != null && stack.getQuantity() > 0) {
+                                       te.pushStack(stack);
+                               }
+                       }
+                       batchPullBuffer.clear();
+               }
+               batchPullBuffer = null;
+       }
 }

--- a/Toms-Storage-120/src/shared/java/com/tom/storagemod/util/TerminalCraftingFiller.java
+++ b/Toms-Storage-120/src/shared/java/com/tom/storagemod/util/TerminalCraftingFiller.java
@@ -247,7 +247,13 @@ public class TerminalCraftingFiller {
                if (batchPullBuffer != null && !batchPullBuffer.isEmpty()) {
                        for (var stack : batchPullBuffer.values()) {
                                if (stack != null && stack.getQuantity() > 0) {
-                                       te.pushStack(stack);
+                                       StoredItemStack remaining = te.pushStack(stack);
+                                       if (remaining != null) {
+                                               ItemStack is = remaining.getActualStack();
+                                               player.getInventory().add(is);
+                                               if (!is.isEmpty())
+                                                       te.dropItem(is);
+                                       }
                                }
                        }
                        batchPullBuffer.clear();


### PR DESCRIPTION
## Summary
- ensure leftover batch items are flushed back into storage
- isolate crafting filler state by storing the filler in the menu
- always refresh cached inventory before filling recipes

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6840b17a6e848323823aa104aed2c3f6